### PR TITLE
Step 1: Customize Template for "Etka Developer VM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-# Linux Developer VM Example / Template
+# Etka Developer VM Example
 
 [![Circle CI](https://circleci.com/gh/Zuehlke/linux-developer-vm/tree/master.svg?style=shield)](https://circleci.com/gh/Zuehlke/linux-developer-vm/tree/master)
 
-A minimal example / template project for a Chef-managed Linux Developer VM.
+A minimal example / template project for a Chef-managed Etka Developer VM.
 
-![Linux Developer VM Screenshot](https://raw.github.com/Zuehlke/linux-developer-vm/master/linux_devbox.png)
+![Etka Developer VM Screenshot](https://raw.github.com/Zuehlke/linux-developer-vm/master/linux_devbox.png)
 
 It's meant to be copy/pasted and filled with life. The `cookbooks/vm` directory
 contains the recipes for setting up the VM and the tests that come along with it.
@@ -146,9 +146,9 @@ $ vagrant ssh -c "sudo umount /vagrant -f"
 Finally, shutdown the VM, remove the sharedfolder, and export the VM as an .ova file:
 ```
 $ vagrant halt
-$ VBoxManage sharedfolder remove "Linux Developer VM" --name "vagrant"
-$ VBoxManage modifyvm "Linux Developer VM" --name "Linux Developer VM v0.1.0"
-$ VBoxManage export "Linux Developer VM v0.1.0" --output "linux-developer-vm-v0.1.0.ova" --options manifest,nomacs
+$ VBoxManage sharedfolder remove "Etka Developer VM" --name "vagrant"
+$ VBoxManage modifyvm "Etka Developer VM" --name "Etka Developer VM v0.1.0"
+$ VBoxManage export "Etka Developer VM v0.1.0" --output "linux-developer-vm-v0.1.0.ova" --options manifest,nomacs
 ```
 
 Don't forget to throw away the VM when you are done:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Finally, shutdown the VM, remove the sharedfolder, and export the VM as an .ova 
 $ vagrant halt
 $ VBoxManage sharedfolder remove "Etka Developer VM" --name "vagrant"
 $ VBoxManage modifyvm "Etka Developer VM" --name "Etka Developer VM v0.1.0"
-$ VBoxManage export "Etka Developer VM v0.1.0" --output "linux-developer-vm-v0.1.0.ova" --options manifest,nomacs
+$ VBoxManage export "Etka Developer VM v0.1.0" --output "etka-developer-vm-v0.1.0.ova" --options manifest,nomacs
 ```
 
 Don't forget to throw away the VM when you are done:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 # Etka Developer VM Example
 
-[![Circle CI](https://circleci.com/gh/Zuehlke/linux-developer-vm/tree/master.svg?style=shield)](https://circleci.com/gh/Zuehlke/linux-developer-vm/tree/master)
+[![Circle CI](https://circleci.com/gh/tknerr/etka2017-developer-vm/tree/master.svg?style=shield)](https://circleci.com/gh/tknerr/etka2017-developer-vm/tree/master)
 
 A minimal example / template project for a Chef-managed Etka Developer VM.
 
-![Etka Developer VM Screenshot](https://raw.github.com/Zuehlke/linux-developer-vm/master/linux_devbox.png)
+![Etka Developer VM Screenshot](https://raw.github.com/tknerr/etka2017-developer-vm/master/linux_devbox.png)
 
 It's meant to be copy/pasted and filled with life. The `cookbooks/vm` directory
 contains the recipes for setting up the VM and the tests that come along with it.
@@ -40,7 +40,7 @@ Other tweaks and settings worth mentioning:
 
 The latest version of this developer VM can be downloaded as a VM image from here:
 
- * https://github.com/Zuehlke/linux-developer-vm/releases
+ * https://github.com/tknerr/etka2017-developer-vm/releases
 
 After downloading the .ova file you can import it into VirtualBox via `File -> Import Appliance...`.
 Once imported, you can simply start the VM and log in:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant::configure("2") do |config|
   end
 
   # set the hostname
-  config.vm.hostname = "linux-developer-vm.local"
+  config.vm.hostname = "etka-developer-vm.local"
   # don't create a new keypair
   config.ssh.insert_key = false
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant::configure("2") do |config|
   # virtualbox customizations
   config.vm.provider :virtualbox do |vbox, override|
     vbox.customize ["modifyvm", :id,
-      "--name", "Linux Developer VM",
+      "--name", "Etka Developer VM",
       "--memory", 1048,
       "--cpus", 4
     ]

--- a/cookbooks/vm/README.md
+++ b/cookbooks/vm/README.md
@@ -1,5 +1,5 @@
-# Linux Developer VM Cookbook
+# Etka Developer VM Cookbook
 
-A cookbook for setting up a basic Linux Developer VM
+A cookbook for setting up the Etka Developer VM example
 
-See: https://github.com/Zuehlke/linux-developer-vm
+See: https://github.com/tknerr/etka2017-developer-vm

--- a/cookbooks/vm/metadata.rb
+++ b/cookbooks/vm/metadata.rb
@@ -1,12 +1,12 @@
 name 'vm'
-maintainer 'Your Name'
-maintainer_email 'your.name@example.com'
+maintainer 'Torben Knerr'
+maintainer_email 'mail@tknerr.de'
 license 'MIT'
-description 'Installs/Configures a Linux Developer VM'
+description 'Installs/Configures the Etka Developer VM example'
 long_description IO.read(File.join(File.dirname(__FILE__), '../../README.md'))
 version '0.1.0'
-issues_url 'https://github.com/Zuehlke/linux-developer-vm/issues'
-source_url 'https://github.com/Zuehlke/linux-developer-vm'
+issues_url 'https://github.com/tknerr/etka2017-developer-vm/issues'
+source_url 'https://github.com/tknerr/etka2017-developer-vm'
 
 chef_version '~> 12'
 


### PR DESCRIPTION
After forking the [Zuehlke/linux-developer-vm](https://github.com/Zuehlke/linux-developer-vm) template project, you should make the following adjustments to make it an "Etka Developer VM":

1. search / replace "Linux Developer VM" with "Etka Developer VM" in `README.md` and `Vagrantfile`
1. adjust hostname in `Vagrantfile` and package name in `README.md` 
1. adjust URLs tp point to tknerr/etka2017-developer-vm instead of Zuehlke/linux-developer-vm in `README.md`
1. adjust information in the vm cookbook's `metadata.rb` and `README.md`

After these changes I made sure that `vagrant up` still works:

![image](https://cloud.githubusercontent.com/assets/365744/25735560/82f3b91c-316c-11e7-9eba-7388d4f6b92c.png)

You should see now that the VM is named "Etka Developer VM" in the VirtualBox GUI:

![image](https://cloud.githubusercontent.com/assets/365744/25735523/44c277a0-316c-11e7-8d41-fc31a57ba803.png)

Also the VM's hostname should be "etka-developer-vm" now:

![image](https://cloud.githubusercontent.com/assets/365744/25735581/b4d3d930-316c-11e7-9e98-0730a8c96a86.png)

The rest are only documentary changes in the README
