### PR TITLE
Step 2: Install Oracle JDK

### DIFF
--- a/cookbooks/vm/Berksfile.lock
+++ b/cookbooks/vm/Berksfile.lock
@@ -5,5 +5,14 @@ DEPENDENCIES
 
 GRAPH
   apt (6.0.1)
+  homebrew (4.1.0)
+  java (1.49.0)
+    apt (>= 0.0.0)
+    homebrew (>= 0.0.0)
+    windows (>= 0.0.0)
+  ohai (5.0.4)
   vm (0.1.0)
     apt (= 6.0.1)
+    java (= 1.49.0)
+  windows (3.0.5)
+    ohai (>= 4.0.0)

--- a/cookbooks/vm/metadata.rb
+++ b/cookbooks/vm/metadata.rb
@@ -13,3 +13,4 @@ chef_version '~> 12'
 supports 'ubuntu'
 
 depends 'apt', '6.0.1'
+depends 'java', '1.49.0'

--- a/cookbooks/vm/recipes/default.rb
+++ b/cookbooks/vm/recipes/default.rb
@@ -6,3 +6,4 @@
 
 include_recipe 'vm::base'
 include_recipe 'vm::vim'
+include_recipe 'vm::java'

--- a/cookbooks/vm/recipes/java.rb
+++ b/cookbooks/vm/recipes/java.rb
@@ -1,0 +1,9 @@
+
+# install java
+node.override['java']['jdk_version'] = '8'
+node.override['java']['install_flavor'] = 'oracle'
+node.override['java']['oracle']['accept_oracle_download_terms'] = true
+node.override['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz'
+node.override['java']['jdk']['8']['x86_64']['checksum'] = '62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236'
+
+include_recipe 'java'

--- a/cookbooks/vm/spec/integration/recipes/java_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/java_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'vm::java' do
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+
+  it 'installs Oracle Java 8u131' do
+    expect(command('java -version').stderr).to contain 'java version "1.8.0_131"'
+  end
+  it 'sets JAVA_HOME correctly' do
+    expect(command('bash -l -c "echo -n \$JAVA_HOME"').stdout).to eq '/usr/lib/jvm/java-8-oracle-amd64'
+  end
+end


### PR DESCRIPTION
Install Oracle JDK version 8u131 and add tests:

 * add [java cookbook](https://supermarket.chef.io/cookbooks/java) dependency in `metadata.rb` and update `Berksfile.lock`
 * add `cookbooks/vm/recipes/java.rb` configuring the parameters for installing Oracle JDK 8u131
 * add `cookbooks/vm/spec/integration/recipes/java_spec.rb` for testing the Java installation

When running `vagrant up` / `vagrant provision` again you should see that Java is installed (i.e. all tests passing):

![image](https://cloud.githubusercontent.com/assets/365744/25741065/68c2dde4-3189-11e7-9ac1-552017373715.png)

Also, when logging in to the VM via the GUI, you should also see that Java is installed correctly (note: you might have to re-login once or run `source /etc/profile && source ~/.bashrc` once for the environment settings to take effect):

![image](https://cloud.githubusercontent.com/assets/365744/25743169/569218d8-3193-11e7-9bea-ccbe2d869c2b.png)

