### PR TITLE
Step 3: Install Maven

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant::configure("2") do |config|
   config.vm.provider :virtualbox do |vbox, override|
     vbox.customize ["modifyvm", :id,
       "--name", "Etka Developer VM",
-      "--memory", 1048,
+      "--memory", 2048,
       "--cpus", 4
     ]
     vbox.gui = true
@@ -34,7 +34,8 @@ Vagrant::configure("2") do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.enable :generic, {
       "chef_file_cache" => { cache_dir: "/root/.chef/local-mode-cache/cache" },
-      "berks_cache" => { cache_dir: "/home/vagrant/.berkshelf" }
+      "berks_cache" => { cache_dir: "/home/vagrant/.berkshelf" },
+      "m2_repo" => { cache_dir: "/home/vagrant/.m2/repository" }
     }
   end
 end

--- a/cookbooks/vm/files/default/desktop_readme.md
+++ b/cookbooks/vm/files/default/desktop_readme.md
@@ -12,7 +12,7 @@ Configure the keyboard layout and adjust the timezone:
 
 If you have a totally different keymap (e.g. on a MacBook) you can always reconfigure it:
 ```
-sudo dpkg-reconfigure keyboard-configuration
+$ sudo dpkg-reconfigure keyboard-configuration
 ```
 
 ## Updating this Developer VM
@@ -26,5 +26,37 @@ You can run these commands from anywhere inside this developer VM:
 
 ## Getting Started!
 
-Please refer to the separate GETTING_STARTED guide (if available) on how to start
-developing with the specific toolchain in this developer VM.
+Please refer to the sections below on how to start developing with the specific toolchain in this developer VM.
+
+### Setup a Java / Maven Example
+
+You can set up a Maven based example RESTful web application as described here:
+https://jersey.java.net/documentation/latest/getting-started.html
+
+Prepare:
+```
+$ mkdir ~/workspace
+$ cd ~/workspace
+```
+
+Scaffold the web application project:
+```
+$ mvn archetype:generate -DarchetypeArtifactId=jersey-quickstart-webapp \
+  -DarchetypeGroupId=org.glassfish.jersey.archetypes -DinteractiveMode=false \
+  -DgroupId=com.example -DartifactId=simple-service-webapp -Dpackage=com.example \
+  -DarchetypeVersion=2.21
+```
+
+Build, test, package:
+```
+$ cd simple-service-webapp
+$ mvn clean install
+```
+
+To run the project in an embedded Tomcat container:
+```
+$ mvn org.apache.tomcat.maven:tomcat7-maven-plugin:run
+```
+
+Once the embedded Tomcat is up and running, you can access the web application here:
+http://localhost:8080/simple-service-webapp/

--- a/cookbooks/vm/recipes/default.rb
+++ b/cookbooks/vm/recipes/default.rb
@@ -7,3 +7,4 @@
 include_recipe 'vm::base'
 include_recipe 'vm::vim'
 include_recipe 'vm::java'
+include_recipe 'vm::maven'

--- a/cookbooks/vm/recipes/maven.rb
+++ b/cookbooks/vm/recipes/maven.rb
@@ -1,0 +1,22 @@
+
+#
+# install maven
+#
+mvn_version = '3.5.0'
+mvn_checksum = 'beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034'
+
+remote_file 'download maven tarball' do
+  source "http://apache.mirrors.tds.net/maven/maven-3/#{mvn_version}/binaries/apache-maven-#{mvn_version}-bin.tar.gz"
+  checksum mvn_checksum
+  path "#{Chef::Config[:file_cache_path]}/maven-#{mvn_version}.tar.gz"
+end
+
+execute 'extract maven tarball' do
+  command "tar xzvf #{Chef::Config[:file_cache_path]}/maven-#{mvn_version}.tar.gz"
+  cwd "/usr/local"
+  creates "/usr/local/apache-maven-#{mvn_version}/bin/mvn"
+end
+
+link '/usr/local/maven' do
+  to "/usr/local/apache-maven-#{mvn_version}"
+end

--- a/cookbooks/vm/recipes/maven.rb
+++ b/cookbooks/vm/recipes/maven.rb
@@ -24,5 +24,7 @@ end
 file '/etc/profile.d/maven.sh' do
   content <<~EOF
     export PATH=/usr/local/maven/bin:$PATH
+    export M2_HOME=/usr/local/maven
+    export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xmx384m"
     EOF
 end

--- a/cookbooks/vm/recipes/maven.rb
+++ b/cookbooks/vm/recipes/maven.rb
@@ -20,3 +20,9 @@ end
 link '/usr/local/maven' do
   to "/usr/local/apache-maven-#{mvn_version}"
 end
+
+file '/etc/profile.d/maven.sh' do
+  content <<~EOF
+    export PATH=/usr/local/maven/bin:$PATH
+    EOF
+end

--- a/cookbooks/vm/spec/integration/recipes/maven_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/maven_spec.rb
@@ -7,4 +7,11 @@ describe 'vm::maven' do
   it 'installs Maven 3.5.0' do
     expect(command('bash -l -c "mvn --version"').stdout).to contain 'Apache Maven 3.5.0'
   end
+
+  it 'sets M2_HOME correctly' do
+    expect(command('bash -l -c "echo -n \$M2_HOME"').stdout).to eq '/usr/local/maven'
+  end
+  it 'sets MAVEN_OPTS to configure memory settings' do
+    expect(command('bash -l -c "echo \$MAVEN_OPTS"').stdout).to contain '-Xmx384m'
+  end
 end

--- a/cookbooks/vm/spec/integration/recipes/maven_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/maven_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'vm::maven' do
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+
+  it 'installs Maven 3.5.0' do
+    expect(command('bash -l -c "mvn --version"').stdout).to contain 'Apache Maven 3.5.0'
+  end
+end


### PR DESCRIPTION
Install Apache Maven 3.5.0, add tests and update the Desktop README:

 * add `cookbooks/vm/recipes/maven.rb` to download / extract / install Maven
 * also set the `M2_HOME` and `MAVEN_OPTS` environment variables
 * add `cookbooks/vm/spec/integration/recipes/maven_spec.rb` for testing the Maven installation
 * adds instructions to the VM Desktop `README.md` with instructions how to generate, build and deploy a sample RESTful web application using maven

When running `vagrant up` / `vagrant provision` again you should see that Maven is installed and the environment variables are set (i.e. all tests passing):

![image](https://cloud.githubusercontent.com/assets/365744/26000882/d4c6ecdc-372a-11e7-8140-f2d8ac55795d.png)

Also, when logging in to the VM via the GUI, you should also see that Maven is installed correctly (note: you might have to re-login once or run `source /etc/profile && source ~/.bashrc` once for the environment settings to take effect):

![image](https://cloud.githubusercontent.com/assets/365744/26000957/1474b3e6-372b-11e7-957b-ebbb47f0edc7.png)

Finally, following the instructions in the updated `README.md` file, you should be able to generate a new example RESTful web application project via `mvn archetype:generate ...` and successfully build that project via `mvn clean install`:

![image](https://cloud.githubusercontent.com/assets/365744/26014110/934da7a6-375b-11e7-934d-c70f853dcfa5.png)

To deploy the example web application use `mvn org.apache.tomcat.maven:tomcat7-maven-plugin:run` and visit http://localhost:8080/simple-service-webapp in your browser: 

![image](https://cloud.githubusercontent.com/assets/365744/26015149/024873e4-3760-11e7-8d8e-1f2f18db03ac.png)

